### PR TITLE
Fix/br 48/password characters

### DIFF
--- a/src/app/reset-password/NewPasswordInput/index.tsx
+++ b/src/app/reset-password/NewPasswordInput/index.tsx
@@ -29,8 +29,8 @@ const schema = yup.object().shape({
     .matches(/[a-z]/, 'Deve conter pelo menos uma letra minúscula')
     .matches(/[0-9]/, 'Deve conter pelo menos um número')
     .matches(
-      /[!@#$%^&*()_]/,
-      'Deve conter pelo menos um dos caracteres: !, @, #, $, %, &, -, ...',
+      /[!@#$%^&*(),._?":{}|<>]/,
+      'Deve conter pelo menos um dos caracteres: [!@#$%^&*(),._?":{}|<>]',
     )
     .min(8, 'A senha deve conter no mínimo 8 caracteres'),
   confirmPassword: yup

--- a/src/app/reset-password/NewPasswordInput/index.tsx
+++ b/src/app/reset-password/NewPasswordInput/index.tsx
@@ -29,8 +29,8 @@ const schema = yup.object().shape({
     .matches(/[a-z]/, 'Deve conter pelo menos uma letra minúscula')
     .matches(/[0-9]/, 'Deve conter pelo menos um número')
     .matches(
-      /[!@#$%^&*(),._?":{}|<>]/,
-      'Deve conter pelo menos um dos caracteres: [!@#$%^&*(),._?":{}|<>]',
+      /[!@#$%^&*(),.?":{}|<>]/,
+      'Deve conter pelo menos um dos caracteres: [!@#$%^&*(),.?":{}|<>]',
     )
     .min(8, 'A senha deve conter no mínimo 8 caracteres'),
   confirmPassword: yup


### PR DESCRIPTION
Foi alterado o regex da função matches do yup que testa os caracteres da senha.
Foi inserido a seguinte regex: [!@#$%^&*(),._?":{}|<>]

Foi alterado o regex para ficar igual ao da tela de criar login