### PR TITLE
[BR-64] FIX(forgot-password-message): Adicionar a mensagem de e-mail não cadastrado.

### DIFF
--- a/src/app/forgot-password/index.tsx
+++ b/src/app/forgot-password/index.tsx
@@ -27,6 +27,7 @@ const schema = yup.object().shape({
 
 export default function ForgotPassword() {
   const [isValidEmail, setIsValidEmail] = useState(false)
+  const [isEmailRegistered, setIsEmailRegistered] = useState(true)
   const {
     control,
     handleSubmit,
@@ -45,6 +46,11 @@ export default function ForgotPassword() {
     } else {
       setIsValidEmail(false)
     }
+
+    if (email.trim().length === 0) {
+      setIsEmailRegistered(true)
+    }
+
   }, [email])
 
   const handleSubmitToApi = async (data: FieldValues) => {
@@ -54,12 +60,15 @@ export default function ForgotPassword() {
       })
 
       if (response.data.statusCode === 204) {
+        setIsEmailRegistered(true)
         router.push('/reset-password')
       } else {
         console.log('Não recebeu o código 204 da API')
       }
     } catch (error) {
+      setIsEmailRegistered(false)
       console.log('Error send email to forgote-password:', error)
+
     }
   }
 
@@ -102,6 +111,9 @@ export default function ForgotPassword() {
             />
             {errors.email && (
               <Text style={globalStyles.errorText}>{errors.email.message}</Text>
+            )}
+            {email && isEmailRegistered === false && (
+              <Text style={globalStyles.errorText}>Email não registrado</Text>
             )}
           </View>
         </View>

--- a/src/app/forgot-password/index.tsx
+++ b/src/app/forgot-password/index.tsx
@@ -27,7 +27,7 @@ const schema = yup.object().shape({
 
 export default function ForgotPassword() {
   const [isValidEmail, setIsValidEmail] = useState(false)
-  const [isEmailRegistered, setIsEmailRegistered] = useState(true)
+  const [isEmailRegistered, setIsEmailRegistered] = useState<Boolean | null>(null)
   const {
     control,
     handleSubmit,
@@ -48,7 +48,7 @@ export default function ForgotPassword() {
     }
 
     if (email.trim().length === 0) {
-      setIsEmailRegistered(true)
+      setIsEmailRegistered(null)
     }
 
   }, [email])
@@ -113,7 +113,7 @@ export default function ForgotPassword() {
               <Text style={globalStyles.errorText}>{errors.email.message}</Text>
             )}
             {email && isEmailRegistered === false && (
-              <Text style={globalStyles.errorText}>Email não registrado</Text>
+              <Text style={globalStyles.errorText}>Houve um erro no seu Email</Text>
             )}
           </View>
         </View>

--- a/src/app/forgot-password/index.tsx
+++ b/src/app/forgot-password/index.tsx
@@ -67,8 +67,8 @@ export default function ForgotPassword() {
       }
     } catch (error) {
       setIsEmailRegistered(false)
+      setIsValidEmail(false)
       console.log('Error send email to forgote-password:', error)
-
     }
   }
 


### PR DESCRIPTION
Foi Adicionado a mensagem de e-mail não cadastrado logo abaixo do input do e-mail.

- Foi criado um estado isEmailRegistered que recebe o valor true ou false se o e-mail estiver cadastrado ou não
- Quando enviado o e-mail para a API e receber o código 404, é mudado o estado isEmailRegistered para false
- Abaixo do input de e-mail tem uma renderização condicional que verifica se o estado isEmailRegistered é false, se for renderiza a mensagem de e-mail não cadastrado.
- Se o input de e-mail ficar em branco ou o estado isEmailRegistered for true a mensagem some.