### PR TITLE
[BR-139] FIX: Informação de Meus Saldos a Pagar está quebrada

### DIFF
--- a/src/components/CarouselItem/style.ts
+++ b/src/components/CarouselItem/style.ts
@@ -31,7 +31,7 @@ export const styles = StyleSheet.create({
   value: {
     fontFamily: theme.fontFamily.bold,
     fontSize: 32,
-    width: width * 0.5,
+    width: width * 0.7,
     color: theme.colors.Gray[500],
   },
   button: {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (Mudanças que corrige um problema)
- [ ] New feature (Mudanças que adiciona uma funcionalidade)
- [ ] Chore (documentação, packages, testes ou atualizações (updates), nada que afeta diretamente o usuario final)
- [ ] Release (Nova versão da aplicação - somente para produção)

## Description

 - Quando inserido um numero muito grande a informação do card quebra para linha de baixo
 - Foi ajustado o width do campo value para crescer 70% do tamanho não que bando assim com valores maiores.

## Screenshots

Screenshot se necessário.

## Tasks

- #BR-139 - [Tela Home]: Informação de Meus Saldos a Pagar está quebrada
