### PR TITLE
[BR-144]: feature(Criar as tabs): Criar as abas de navegação no centro da tela de convites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,12 @@
         "react-hook-form": "^7.51.5",
         "react-native": "0.74.5",
         "react-native-gesture-handler": "~2.16.1",
+        "react-native-pager-view": "6.3.0",
         "react-native-reanimated": "~3.10.1",
         "react-native-safe-area-context": "4.10.5",
         "react-native-screens": "3.31.1",
         "react-native-svg": "15.2.0",
+        "react-native-tab-view": "^3.5.2",
         "react-native-web": "~0.19.10",
         "yup": "^1.4.0",
         "zustand": "^4.5.2"
@@ -18718,6 +18720,16 @@
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-native-pager-view": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.3.0.tgz",
+      "integrity": "sha512-ufJOoVa9pFL1J/yb4hpsCqp8n1qTlcF5VvwqvCacHX//D7hSeRscsiIXg1u1pXNWwllvACb+mqxec/3Uj2mxrA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-reanimated": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.10.1.tgz",
@@ -18789,6 +18801,20 @@
       "peerDependencies": {
         "react-native": ">=0.59.0",
         "react-native-svg": ">=12.0.0"
+      }
+    },
+    "node_modules/react-native-tab-view": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-3.5.2.tgz",
+      "integrity": "sha512-nE5WqjbeEPsWQx4mtz81QGVvgHRhujTNIIZiMCx3Bj6CBFDafbk7XZp9ocmtzXUQaZ4bhtVS43R4FIiR4LboJw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-latest-callback": "^0.1.5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-pager-view": "*"
       }
     },
     "node_modules/react-native-web": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-font": "~12.0.6",
     "expo-linking": "~6.3.1",
     "expo-router": "~3.5.23",
+    "expo-secure-store": "~13.0.2",
     "expo-splash-screen": "~0.27.5",
     "expo-status-bar": "~1.12.1",
     "expo-system-ui": "~3.0.7",
@@ -39,10 +40,11 @@
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
     "react-native-svg": "15.2.0",
+    "react-native-tab-view": "^3.5.2",
     "react-native-web": "~0.19.10",
     "yup": "^1.4.0",
     "zustand": "^4.5.2",
-    "expo-secure-store": "~13.0.2"
+    "react-native-pager-view": "6.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/app/(tabs)/friends/index.tsx
+++ b/src/app/(tabs)/friends/index.tsx
@@ -15,7 +15,7 @@ export default function Amigos() {
         <View style={styles.containerText}>
           <Text style={styles.text}>4 convites enviados</Text>
           <Link
-            href="/friends/invitations"
+            href="/friends/invitations?initialIndex=0"
             style={[styles.text, { textDecorationLine: 'underline' }]}
           >
             Ver
@@ -24,7 +24,7 @@ export default function Amigos() {
         <View style={styles.containerText}>
           <Text style={styles.text}>3 solicitações de amizade pendentes</Text>
           <Link
-            href="/friends/invitations"
+            href="/friends/invitations?initialIndex=1"
             style={[styles.text, { textDecorationLine: 'underline' }]}
           >
             Ver

--- a/src/app/(tabs)/friends/invitations.tsx
+++ b/src/app/(tabs)/friends/invitations.tsx
@@ -1,12 +1,72 @@
-import { View } from 'react-native'
+import { useState } from 'react'
+import { Text, useWindowDimensions, View } from 'react-native'
+import { useLocalSearchParams } from 'expo-router'
+import { TabView, SceneMap, TabBar, TabBarProps } from 'react-native-tab-view'
+
 import AddFriendButton from '@/src/components/AddFriendButton'
 
 import { styles } from './styles'
+import { theme } from '@/src/theme'
+import { verticalScale } from '@/src/utils/responsiveUtils'
+
+type Route = {
+  key: string
+  title: string
+}
+
+const SentRequestSection = () => (
+  <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <Text>Enviados</Text>
+  </View>
+)
+
+const PendingRequestSection = () => (
+  <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <Text>Pendentes</Text>
+  </View>
+)
+
+const renderScene = SceneMap({
+  enviados: SentRequestSection,
+  pendentes: PendingRequestSection,
+})
+
+const RenderTabBar = (props: TabBarProps<Route>) => (
+  <TabBar
+    {...props}
+    indicatorStyle={{ backgroundColor: theme.colors.primaryColor }}
+    style={{ backgroundColor: theme.colors.white }}
+    renderLabel={({ route, focused }: { route: Route; focused: boolean }) => (
+      <Text style={[styles.text, focused && styles.tabLabelActive]}>
+        {route.title}
+      </Text>
+    )}
+  />
+)
 
 export default function Invitations() {
+  const { initialIndex } = useLocalSearchParams()
+  const [index, setIndex] = useState<number>(Number(initialIndex) || 0)
+
+  const [routes] = useState<Route[]>([
+    { key: 'enviados', title: 'Enviados' },
+    { key: 'pendentes', title: 'Pendentes' },
+  ])
+
+  const layout = useWindowDimensions()
+
   return (
     <View style={styles.container}>
       <AddFriendButton />
+
+      <TabView
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        onIndexChange={setIndex}
+        initialLayout={{ width: layout.width }}
+        renderTabBar={RenderTabBar}
+        style={{ marginTop: verticalScale(24) }}
+      />
     </View>
   )
 }

--- a/src/app/(tabs)/friends/styles.ts
+++ b/src/app/(tabs)/friends/styles.ts
@@ -26,4 +26,8 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
   },
+  tabLabelActive: {
+    fontSize: rem(18),
+    fontFamily: theme.fontFamily.semiBold,
+  },
 })


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (Mudanças que corrige um problema)
- [x] New feature (Mudanças que adiciona uma funcionalidade)
- [ ] Chore (documentação, packages, testes ou atualizações (updates), nada que afeta diretamente o usuario final)
- [ ] Release (Nova versão da aplicação - somente para produção)

## Description
Criar a Tab View da Pagina de Convites
- Utilizar a lib "Tab View" do "React Navigation"
- Configurar o layout das tabs bem como as cores conforme o figma utilizando os recurso da própria Lib "TabView"
- Configurar o titulo das tabs para ficar negrito se estiver ativa
- Inserir Query paramater no link na pagina Amigos que leva para a pagina convites
 - No parâmetro é passado a propriedade initialIndex que servirá como referencia para Tab inicial quando a pagina for renderizada. Se initialIndex for 0 será renderizado a Tab Enviados, se for 1 será renderizado a Tab pendencia.
 - Dentro da Pagina tem o componente "RenderTabBar" que renderiza o titulo, e o indicador no topo das tabs.
 - O renderScene renderiza os componentes que serão os conteúdos de cada tab
 - o navigationState e o onIndexChange controla quantas tabs terão e qual tab está ativa no momento.

## Tasks

- #BR-144 - Criar as abas de navegação no centro da tela de convites