### PR TITLE
Feature/tela 1.3.4

### DIFF
--- a/src/app/(tabs)/expenses/_layout.tsx
+++ b/src/app/(tabs)/expenses/_layout.tsx
@@ -1,7 +1,7 @@
-import { router, Stack } from 'expo-router'
+import { router, Stack } from "expo-router";
 
-import LeftIcon from '@/src/assets/images/arrowBack.svg'
-import Question from '@/src/assets/images/question.svg'
+import LeftIcon from "@/src/assets/images/arrowBack.svg";
+import Question from "@/src/assets/images/question.svg";
 
 export default function ExpensesLayout() {
   return (
@@ -13,13 +13,13 @@ export default function ExpensesLayout() {
       <Stack.Screen
         name="newExpense/index"
         options={{
-          title: 'Nova Despesa',
+          title: "Nova Despesa",
           headerShown: true,
-          headerTitleAlign: 'center',
+          headerTitleAlign: "center",
           headerLeft: () => (
             <LeftIcon
               onPress={() => {
-                router.push('/home')
+                router.push("/home");
               }}
             />
           ),
@@ -29,13 +29,13 @@ export default function ExpensesLayout() {
       <Stack.Screen
         name="newExpense/value/index"
         options={{
-          title: 'Valor',
+          title: "Valor",
           headerShown: true,
-          headerTitleAlign: 'center',
+          headerTitleAlign: "center",
           headerLeft: () => (
             <LeftIcon
               onPress={() => {
-                router.back()
+                router.back();
               }}
             />
           ),
@@ -46,13 +46,13 @@ export default function ExpensesLayout() {
       <Stack.Screen
         name="newExpense/group/index"
         options={{
-          title: 'Grupo',
+          title: "Grupo",
           headerShown: true,
-          headerTitleAlign: 'center',
+          headerTitleAlign: "center",
           headerLeft: () => (
             <LeftIcon
               onPress={() => {
-                router.back()
+                router.back();
               }}
             />
           ),
@@ -63,13 +63,30 @@ export default function ExpensesLayout() {
       <Stack.Screen
         name="newExpense/payers/index"
         options={{
-          title: 'Pagador',
+          title: "Pagador",
           headerShown: true,
-          headerTitleAlign: 'center',
+          headerTitleAlign: "center",
           headerLeft: () => (
             <LeftIcon
               onPress={() => {
-                router.back()
+                router.back();
+              }}
+            />
+          ),
+          headerRight: () => <Question />,
+        }}
+      />
+
+      <Stack.Screen
+        name="newExpense/receivers/index"
+        options={{
+          title: "Para quem?",
+          headerShown: true,
+          headerTitleAlign: "center",
+          headerLeft: () => (
+            <LeftIcon
+              onPress={() => {
+                router.back();
               }}
             />
           ),
@@ -80,18 +97,18 @@ export default function ExpensesLayout() {
       <Stack.Screen
         name="newExpense/resume/index"
         options={{
-          title: 'Resumo',
+          title: "Resumo",
           headerShown: true,
-          headerTitleAlign: 'center',
+          headerTitleAlign: "center",
           headerLeft: () => (
             <LeftIcon
               onPress={() => {
-                router.back()
+                router.back();
               }}
             />
           ),
         }}
       />
     </Stack>
-  )
+  );
 }

--- a/src/app/(tabs)/expenses/newExpense/group/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/group/index.tsx
@@ -49,6 +49,10 @@ export default function SelectGroup() {
           },
         });
         setGroups(data.data);
+
+        if (expenseData.idGrupo) {
+          setSelectedGroup(expenseData.idGrupo);
+        }
       } catch (error) {
         __DEV__ && console.log("Houve um erro ao buscar os grupos", error);
       }

--- a/src/app/(tabs)/expenses/newExpense/group/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/group/index.tsx
@@ -74,7 +74,7 @@ export default function SelectGroup() {
 
     setExpenseData({
       ...expenseData,
-      grupoId: selectedGroup,
+      idGrupo: selectedGroup,
       userCod,
     });
 

--- a/src/app/(tabs)/expenses/newExpense/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/index.tsx
@@ -1,37 +1,39 @@
-import { useState } from 'react'
-import { Text, View, TextInput, TouchableOpacity, KeyboardAvoidingView } from 'react-native'
-import { Ionicons } from '@expo/vector-icons'
-import { useForm, Controller, useWatch } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
-import * as yup from 'yup'
-import { router } from 'expo-router'
+import { useState } from "react";
+import {
+  Text,
+  View,
+  TextInput,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useForm, Controller, useWatch } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import { router } from "expo-router";
 
-import { ButtonCustomizer } from '@/src/components/ButtonCustomizer'
-import { CalendarComponent } from '@/src/components/CalendarComponent'
-import { useExpenseStore } from '@/src/store/useExpenseStore'
-import { theme } from '@/src/theme'
-import { styles } from './styles'
-import ProgressBarComponent from '@/src/components/ProgressBarComponent'
+import { ButtonCustomizer } from "@/src/components/ButtonCustomizer";
+import { CalendarComponent } from "@/src/components/CalendarComponent";
+import { useExpenseStore } from "@/src/store/useExpenseStore";
+import { theme } from "@/src/theme";
+import { styles } from "./styles";
+import ProgressBarComponent from "@/src/components/ProgressBarComponent";
 
 interface FormData {
-  expenseName: string
-  description?: string
+  expenseName: string;
+  description?: string;
 }
 
 const schema = yup.object().shape({
-  expenseName: yup
-    .string()
-    .required('Nome da despesa é obrigatório'),
-  description: yup
-    .string()
-    .optional(),
-})
+  expenseName: yup.string().required("Nome da despesa é obrigatório"),
+  description: yup.string().optional(),
+});
 
 export default function NewExpense() {
-  const [showCalendar, setShowCalendar] = useState(false)
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null)
+  const [showCalendar, setShowCalendar] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
-  const { expenseData, setExpenseData } = useExpenseStore()
+  const { expenseData, setExpenseData } = useExpenseStore();
 
   const {
     control,
@@ -40,52 +42,58 @@ export default function NewExpense() {
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
-      expenseName: expenseData.expenseName || '',
-      description: expenseData.description || '',
+      expenseName: expenseData.nome || "",
+      description: expenseData.descricao || "",
     },
-  })
+  });
 
-  const expenseName = useWatch({ control, name: 'expenseName', defaultValue: '' })
+  const expenseName = useWatch({
+    control,
+    name: "expenseName",
+    defaultValue: "",
+  });
 
   const formatDate = (date: Date | null) => {
     if (!date || !(date instanceof Date) || isNaN(date.getTime())) {
-      return 'DD / MM / YYYY'
+      return "DD / MM / YYYY";
     }
 
-    return date.toLocaleDateString('pt-BR', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    })
-  }
+    return date.toLocaleDateString("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    });
+  };
 
-  const canProceed = expenseName.trim().length >= 1 && selectedDate !== null
+  const canProceed = expenseName.trim().length >= 1 && selectedDate !== null;
 
   const openCalendar = () => {
-    setShowCalendar(true)
-  }
+    setShowCalendar(true);
+  };
 
   const closeCalendar = () => {
-    setShowCalendar(false)
-  }
+    setShowCalendar(false);
+  };
 
   const handleNext = (data: FormData) => {
     const expenseDataToStore = {
-      expenseName: data.expenseName,
-      description: data.description,
-      selectedDate: selectedDate,
-    }
+      nome: data.expenseName,
+      descricao: data.description,
+      dataRealizacao: selectedDate,
+    };
 
-    setExpenseData(expenseDataToStore)
-    router.push('/expenses/newExpense/value')
-  }
+    setExpenseData(expenseDataToStore);
+    router.push("/expenses/newExpense/value");
+  };
 
   return (
     <KeyboardAvoidingView style={styles.modalContainer}>
       <ProgressBarComponent totalSteps={100} currentStep={20} />
       <View style={styles.formContainer}>
         <View style={styles.inputGroup}>
-          <Text style={styles.label}>Como você deseja chamar essa despesa?</Text>
+          <Text style={styles.label}>
+            Como você deseja chamar essa despesa?
+          </Text>
           <Controller
             control={control}
             name="expenseName"
@@ -111,7 +119,9 @@ export default function NewExpense() {
           ) : null}
         </View>
         <View style={styles.inputGroup}>
-          <Text style={styles.label}>Deseja adicionar uma descrição? (opcional)</Text>
+          <Text style={styles.label}>
+            Deseja adicionar uma descrição? (opcional)
+          </Text>
           <Controller
             control={control}
             name="description"
@@ -131,14 +141,12 @@ export default function NewExpense() {
         </View>
         <View style={styles.inputGroup}>
           <Text style={styles.label}>Em que data foi realizada?</Text>
-          <TouchableOpacity
-            style={styles.dateInput}
-            onPress={openCalendar}
-          >{selectedDate ? <Text style={styles.dateText}>
-            {formatDate(selectedDate)}
-          </Text> : <Text style={styles.helperDateText}>
-            {'DD / MM / YYYY'}
-          </Text>}
+          <TouchableOpacity style={styles.dateInput} onPress={openCalendar}>
+            {selectedDate ? (
+              <Text style={styles.dateText}>{formatDate(selectedDate)}</Text>
+            ) : (
+              <Text style={styles.helperDateText}>{"DD / MM / YYYY"}</Text>
+            )}
             <Ionicons name="calendar" size={24} color={theme.colors.fourth} />
           </TouchableOpacity>
         </View>
@@ -169,14 +177,19 @@ export default function NewExpense() {
             title="Continuar"
             customStyles={styles.nextButtonText}
           />
-          <Ionicons name="arrow-forward" size={20} color={theme.colors.white} style={{ marginLeft: 8 }} />
+          <Ionicons
+            name="arrow-forward"
+            size={20}
+            color={theme.colors.white}
+            style={{ marginLeft: 8 }}
+          />
         </ButtonCustomizer.Root>
       </View>
       <CalendarComponent
         visible={showCalendar}
         onClose={closeCalendar}
         onConfirm={(d) => {
-          setSelectedDate(d)
+          setSelectedDate(d);
         }}
         defaultValue={selectedDate ?? null}
         autoSelectIfEmpty
@@ -185,5 +198,5 @@ export default function NewExpense() {
         title="Selecionar data"
       />
     </KeyboardAvoidingView>
-  )
+  );
 }

--- a/src/app/(tabs)/expenses/newExpense/payers/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/payers/index.tsx
@@ -50,6 +50,10 @@ export default function Payers() {
         );
 
         setParticipants(data.data);
+
+        if (expenseData.recebedores) {
+          setSelectedParticipants(expenseData.recebedores);
+        }
       } catch (error) {
         console.log("Error: ", error);
       }

--- a/src/app/(tabs)/expenses/newExpense/payers/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/payers/index.tsx
@@ -44,7 +44,7 @@ export default function Payers() {
           "participantes/lista-participantes",
           {
             params: {
-              grupoId: expenseData.grupoId,
+              grupoId: expenseData.idGrupo,
             },
           }
         );

--- a/src/app/(tabs)/expenses/newExpense/receivers/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/receivers/index.tsx
@@ -49,6 +49,10 @@ export default function Receivers() {
           }
         );
         setParticipants(data.data);
+
+        if (expenseData.pagadores) {
+          setSelectedParticipants(expenseData.pagadores);
+        }
       } catch (error) {
         console.log("Error: ", error);
       }
@@ -123,6 +127,7 @@ export default function Receivers() {
                         ? theme.colors.primaryColor
                         : undefined
                     }
+                    disabled={isPayer}
                   />
                 </View>
               </TouchableOpacity>

--- a/src/app/(tabs)/expenses/newExpense/receivers/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/receivers/index.tsx
@@ -28,7 +28,7 @@ interface ParticipantType {
   hasPendent: boolean;
 }
 
-export default function Payers() {
+export default function Receivers() {
   const { expenseData, setExpenseData } = useExpenseStore();
   const { userCod } = useAuthStore();
 
@@ -48,7 +48,6 @@ export default function Payers() {
             },
           }
         );
-
         setParticipants(data.data);
       } catch (error) {
         console.log("Error: ", error);
@@ -69,11 +68,7 @@ export default function Payers() {
     if (selectedParticipants.length === 0) {
       return;
     }
-    setExpenseData({
-      ...expenseData,
-      recebedores: selectedParticipants,
-    });
-    router.push("/expenses/newExpense/receivers");
+    // router.push('/expenses/newExpense/resume')
   }
 
   return (
@@ -81,10 +76,9 @@ export default function Payers() {
       <ProgressBarComponent totalSteps={100} currentStep={80} />
 
       <View style={styles.containerDescription}>
-        <Text style={styles.title}>Quem bancou a despesa?</Text>
+        <Text style={styles.title}>Quem vai rachar?</Text>
         <Text style={styles.text}>
-          Indique quem quitou esta conta — quem for marcado receberá os
-          pagamentos
+          Selecione os amigos que dividirão essa despesa.
         </Text>
       </View>
 
@@ -93,29 +87,43 @@ export default function Payers() {
           data={participants ?? []}
           keyExtractor={(item) => item.participanteId}
           showsVerticalScrollIndicator={false}
-          renderItem={({ item }) => (
-            <TouchableOpacity style={styles.containerItem}>
-              <View style={styles.itemContent}>
-                <View style={styles.containerUser}>
-                  <View style={styles.userIcon}>
-                    <UserIcon width={26} height={26} />
-                  </View>
+          renderItem={({ item }) => {
+            const isPayer = (expenseData.recebedores ?? []).includes(
+              item.participanteId
+            );
 
-                  <Text style={styles.checkboxText}>{item.nome}</Text>
+            return (
+              <TouchableOpacity style={styles.containerItem}>
+                <View style={styles.itemContent}>
+                  <View style={styles.containerUser}>
+                    <View style={styles.userIcon}>
+                      <UserIcon width={26} height={26} />
+                    </View>
+
+                    <View style={styles.payerContainer}>
+                      <Text style={styles.checkboxText}>{item.nome}</Text>
+
+                      {isPayer && (
+                        <Text style={styles.payerText}>
+                          Essa é a pessoa que quitou a despesa.
+                        </Text>
+                      )}
+                    </View>
+                  </View>
+                  <Checkbox
+                    style={styles.checkbox}
+                    value={selectedParticipants.includes(item.participanteId)}
+                    onValueChange={() => toggleSelection(item.participanteId)}
+                    color={
+                      selectedParticipants.includes(item.participanteId)
+                        ? theme.colors.primaryColor
+                        : undefined
+                    }
+                  />
                 </View>
-                <Checkbox
-                  style={styles.checkbox}
-                  value={selectedParticipants.includes(item.participanteId)}
-                  onValueChange={() => toggleSelection(item.participanteId)}
-                  color={
-                    selectedParticipants.includes(item.participanteId)
-                      ? theme.colors.primaryColor
-                      : undefined
-                  }
-                />
-              </View>
-            </TouchableOpacity>
-          )}
+              </TouchableOpacity>
+            );
+          }}
         />
       </View>
 

--- a/src/app/(tabs)/expenses/newExpense/receivers/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/receivers/index.tsx
@@ -44,7 +44,7 @@ export default function Receivers() {
           "participantes/lista-participantes",
           {
             params: {
-              grupoId: expenseData.grupoId,
+              grupoId: expenseData.idGrupo,
             },
           }
         );
@@ -68,7 +68,11 @@ export default function Receivers() {
     if (selectedParticipants.length === 0) {
       return;
     }
-    // router.push('/expenses/newExpense/resume')
+    setExpenseData({
+      ...expenseData,
+      pagadores: selectedParticipants,
+    });
+    router.push("/expenses/newExpense/resume");
   }
 
   return (

--- a/src/app/(tabs)/expenses/newExpense/receivers/styles.tsx
+++ b/src/app/(tabs)/expenses/newExpense/receivers/styles.tsx
@@ -1,0 +1,137 @@
+import { StyleSheet } from "react-native";
+import { theme } from "@/src/theme";
+import {
+  verticalScale,
+  horizontalScale,
+  rem,
+} from "@/src/utils/responsiveUtils";
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.white,
+    paddingHorizontal: horizontalScale(24),
+    paddingVertical: verticalScale(24),
+  },
+  containerDescription: {
+    flexDirection: "column",
+    alignItems: "flex-start",
+    justifyContent: "center",
+  },
+  title: {
+    fontFamily: theme.fontFamily.bold,
+    fontSize: rem(24),
+    lineHeight: 24,
+    color: theme.colors.primaryColor,
+    paddingVertical: verticalScale(12),
+  },
+  text: {
+    fontFamily: theme.fontFamily.regular,
+    fontSize: 16,
+    lineHeight: 24,
+    color: theme.colors.primaryColor,
+  },
+  textBold: {
+    fontFamily: theme.fontFamily.bold,
+    fontSize: 18,
+    lineHeight: 24,
+    color: theme.colors.primaryColor,
+  },
+  containerList: {
+    flex: 1,
+    paddingVertical: verticalScale(12),
+  },
+  containerItem: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 8,
+    paddingVertical: verticalScale(10),
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.Gray[300],
+  },
+  itemContent: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 16,
+  },
+  containerUser: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  userIcon: {
+    backgroundColor: theme.colors.third,
+    borderRadius: 50,
+    padding: 8,
+    width: 48,
+    height: 48,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  checkbox: {
+    borderColor: theme.colors.primaryColor,
+    borderWidth: 2,
+    borderRadius: 4,
+  },
+  payerContainer: {
+    flexDirection: "column",
+  },
+  checkboxText: {
+    fontFamily: theme.fontFamily.regular,
+    fontSize: 16,
+    color: theme.colors.primaryColor,
+  },
+  payerText: {
+    fontFamily: theme.fontFamily.regular,
+    fontSize: 12,
+    color: theme.colors.Gray[400],
+  },
+  containerButton: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  nextButton: {
+    flex: 1,
+    height: 48,
+    backgroundColor: theme.colors.Gray[600],
+    borderRadius: 8,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+  },
+  nextButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: theme.colors.white,
+    fontFamily: theme.fontFamily.semiBold,
+  },
+  backButton: {
+    flex: 1,
+    height: 48,
+    backgroundColor: theme.colors.secondaryColor,
+    borderRadius: 8,
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  backButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: theme.colors.primaryColor,
+    fontFamily: theme.fontFamily.semiBold,
+  },
+  disabledButton: {
+    flex: 1,
+    height: 48,
+    borderRadius: 8,
+    backgroundColor: theme.colors.fourth,
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});

--- a/src/app/(tabs)/expenses/newExpense/resume/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/resume/index.tsx
@@ -4,28 +4,28 @@ import {
   Text,
   TouchableOpacity,
   View,
-} from 'react-native'
-import { useExpenseStore } from '@/src/store/useExpenseStore'
+} from "react-native";
+import { useExpenseStore } from "@/src/store/useExpenseStore";
 
-import PencilIcon from '@/src/assets/images/pencil-strong.svg'
-import { styles } from './styles'
-import { styles as globalStyles } from '@/src/app/styles'
-import { ButtonCustomizer } from '@/src/components/ButtonCustomizer'
-import { router } from 'expo-router'
+import PencilIcon from "@/src/assets/images/pencil-strong.svg";
+import { styles } from "./styles";
+import { styles as globalStyles } from "@/src/app/styles";
+import { ButtonCustomizer } from "@/src/components/ButtonCustomizer";
+import { router } from "expo-router";
 
-const formatadorMoeda = new Intl.NumberFormat('pt-BR', {
-  style: 'currency',
-  currency: 'BRL',
-})
+const formatadorMoeda = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+});
 
 export default function Resume() {
-  const { expenseData } = useExpenseStore()
+  const { expenseData } = useExpenseStore();
   const ListItem = ({
     title,
     content,
   }: {
-    title: string
-    content: string | number | undefined
+    title: string;
+    content: string | number | undefined;
   }) => {
     return (
       <View style={styles.listItem}>
@@ -37,33 +37,34 @@ export default function Resume() {
           <PencilIcon width={20} height={20} />
         </TouchableOpacity>
       </View>
-    )
-  }
+    );
+  };
 
   return (
     <ScrollView style={styles.container}>
-      <ListItem title="O que" content={expenseData?.expenseName} />
+      <ListItem title="O que" content={expenseData?.nome} />
       <ListItem
         title="Quanto"
         content={
-          expenseData?.value && formatadorMoeda.format(expenseData.value)
+          expenseData?.valorDespesa &&
+          formatadorMoeda.format(expenseData?.valorDespesa)
         }
       />
-      <ListItem title="Onde (Grupo)" content={expenseData?.grupoId} />
+      <ListItem title="Onde (Grupo)" content={expenseData?.idGrupo} />
       <ListItem
         title="Quem bancou"
-        content={expenseData?.recebedores?.join(',')}
+        content={expenseData?.recebedores?.join(",")}
       />
       <ListItem
         title="Quem vai pagar"
-        content={expenseData?.recebedores?.join(',')}
+        content={expenseData?.pagadores?.join(",")}
       />
       <ListItem
         title="Quando"
-        content={expenseData?.selectedDate?.toLocaleDateString('pt-BR')}
+        content={expenseData?.dataRealizacao?.toLocaleDateString("pt-BR")}
       />
-      {expenseData?.description && (
-        <ListItem title="Descrição" content={expenseData?.description} />
+      {expenseData?.descricao && (
+        <ListItem title="Descrição" content={expenseData?.descricao} />
       )}
 
       <View style={styles.buttonContainer}>
@@ -80,7 +81,7 @@ export default function Resume() {
 
         <ButtonCustomizer.Root
           type="primaryHalfWidth"
-          onPress={() => console.log('teste')}
+          onPress={() => console.log("teste")}
           customStyles={globalStyles.primaryButtonHalfWidth}
         >
           <ButtonCustomizer.Title
@@ -90,5 +91,5 @@ export default function Resume() {
         </ButtonCustomizer.Root>
       </View>
     </ScrollView>
-  )
+  );
 }

--- a/src/app/(tabs)/expenses/newExpense/value/index.tsx
+++ b/src/app/(tabs)/expenses/newExpense/value/index.tsx
@@ -56,7 +56,7 @@ export default function ExpenseValue() {
   const { control, handleSubmit } = useForm<FormData>({
     resolver: yupResolver(schema),
     defaultValues: {
-      valueDigits: numberToDigits(expenseData.value),
+      valueDigits: numberToDigits(expenseData.valorDespesa),
     },
     mode: "onChange",
   });
@@ -66,7 +66,7 @@ export default function ExpenseValue() {
 
   const handleNext = (data: FormData) => {
     const numValue = digitsToNumber(data.valueDigits);
-    setExpenseData({ ...expenseData, value: numValue });
+    setExpenseData({ ...expenseData, valorDespesa: numValue });
     router.push("/expenses/newExpense/group");
   };
 

--- a/src/store/useExpenseStore.ts
+++ b/src/store/useExpenseStore.ts
@@ -1,19 +1,20 @@
-import { create } from 'zustand'
+import { create } from "zustand";
 
 export interface ExpenseData {
-  expenseName?: string
-  description?: string
-  selectedDate?: Date | null
-  value?: number
-  grupoId?: string
-  userCod?: string | null
-  recebedores?: string[]
+  nome?: string;
+  descricao?: string;
+  dataRealizacao?: Date | null;
+  valorDespesa?: number;
+  idGrupo?: string;
+  userCod?: string | null;
+  recebedores?: string[];
+  pagadores?: string[];
 }
 
 interface ExpenseState {
-  expenseData: ExpenseData
-  setExpenseData: (data: ExpenseData) => void
-  removeExpenseData: () => void
+  expenseData: ExpenseData;
+  setExpenseData: (data: ExpenseData) => void;
+  removeExpenseData: () => void;
 }
 
 export const useExpenseStore = create<ExpenseState>((set) => ({
@@ -24,4 +25,4 @@ export const useExpenseStore = create<ExpenseState>((set) => ({
       expenseData: { ...state.expenseData, ...data },
     })),
   removeExpenseData: () => set({ expenseData: {} }),
-}))
+}));


### PR DESCRIPTION
## Tela 1.3.4 e ajustes na Store 
- [BR-90] feat(Receivers-Page): Implementar tela 1.3.4 de seleção de participantes  

## Type of change  

- [ ] Bug fix (Mudanças que corrige um problema)  
- [x] New feature (Mudanças que adiciona uma funcionalidade)  
- [ ] Chore (documentação, packages, testes ou atualizações (updates), nada que afeta diretamente o usuário final)  
- [ ] Release (Nova versão da aplicação - somente para produção)  

## Description  

Esta PR implementa a **tela 1.3.4 (Receivers)** do fluxo de criação de despesas.  

- Exibe todos os participantes do grupo.  
- Identifica os participantes que **bancaram a despesa** (selecionados na tela 1.3.3), exibindo a mensagem "Essa é a pessoa que quitou a despesa".  
- Permite selecionar outros participantes que irão **dividir a despesa**.  
- Integração com o estado global (`useExpenseStore`) para salvar os `pagadores`.  
- Mantém o comportamento esperado ao editar a partir da tela de resumo (preenche automaticamente as seleções anteriores). 
- Ajustados nomes no estado global (`useExpenseStore`) para o esperado pelo backend. 

## Screenshots  

<img width="400" height="813" alt="image" src="https://github.com/user-attachments/assets/ea0595c8-c44a-40d0-8b4a-2444c5fa8b0a" />

<img width="400" height="812" alt="image" src="https://github.com/user-attachments/assets/6e9e9bed-46cf-4d1d-ae8d-d13bbca7c8a5" />


## Tasks  

- #BR-90 - Implementar tela 1.3.4 de seleção de participantes  

## Dependencies  

Esta pull request tem dependência de outras Pull Requests:  
- N/A  